### PR TITLE
Closes #2: Cards are not displayed full width in MS teams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ config.py
 .DS_Store
 sandbox.py
 .vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ You can inspect any object's JSON payload by calling its `serialize()` method. T
  'contentType': 'application/vnd.microsoft.card.adaptive'}
 ```
 
+#### Microsoft Teams-specific card properties.
+If you want to display your card(s) over the full width in a Teams channel (especially for desktop), then add the following code to your card config:
+
+```python
+card.msteams = {"width": "Full"}
+```
+
 ### HTTP Tuning
 
 #### HTTPS Certificate Verification

--- a/msteams_webhooks/__version__.py
+++ b/msteams_webhooks/__version__.py
@@ -1,4 +1,4 @@
 """msteams_webhooks.__version__."""
 __title__ = "msteams_webhooks"
 __description__ = "A modern Python API for sending messages to Microsoft Teams using webhooks."
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/msteams_webhooks/cards.py
+++ b/msteams_webhooks/cards.py
@@ -38,6 +38,7 @@ class AdaptiveCard(Card):
         lang: Optional[str] = None,
         vertical_content_alignment: Optional[types.VerticalAlignmentTypes] = None,
         schema: Optional[str] = None,
+        msteams: Optional[dict[str, Any]] = None,
     ) -> None:
         """An Adaptive Card, containing a free-form body of card elements.
 
@@ -61,6 +62,10 @@ class AdaptiveCard(Card):
                 within the container. Only relevant for fixed-height cards, or cards with a
                 `min_height` specified.
             schema: Card schema URL.
+            msteams: Microsoft Teams-specific card properties. Primarily used for full width
+                styling of cards/messages. For full screen width card add the following line
+                to your card config: ``card.msteams={"width": "Full"}``.
+
 
         Returns:
             None.
@@ -78,6 +83,7 @@ class AdaptiveCard(Card):
         self.lang = lang
         self.vertical_content_alignment = vertical_content_alignment
         self.schema = schema or "http://adaptivecards.io/schemas/adaptive-card.json"
+        self.msteams = msteams
 
     def serialize(self) -> dict[str, Any]:
         """Serialize object into data structure."""
@@ -103,6 +109,8 @@ class AdaptiveCard(Card):
             payload["content"]["speak"] = self.speak
         if self.lang:
             payload["content"]["lang"] = self.lang
+        if self.msteams:
+            payload["content"]["msteams"] = self.msteams
         if self.vertical_content_alignment:
             payload["content"]["verticalContentAlignment"] = self.vertical_content_alignment
         return payload


### PR DESCRIPTION
This commit ads the ability to set the card.msteams property. Primarily used to make the card  display over the full width in MS Teams (on desktop, but is responsive).

All tests (using Nox) were succesfull.